### PR TITLE
Set an empty array when updating an empty content element

### DIFF
--- a/app/controllers/pulitzer/content_elements_controller.rb
+++ b/app/controllers/pulitzer/content_elements_controller.rb
@@ -26,7 +26,7 @@ class Pulitzer::ContentElementsController < Pulitzer::ApplicationController
   protected
 
   def content_element_params
-    params[:content_element].permit!
+    params[:content_element].nil? ? {} : params[:content_element].permit!
   end
 
   def set_content_element


### PR DESCRIPTION
It happens when the update button is clicked without selecting a new image.
![screen shot 2017-02-17 at 10 08 13 am](https://cloud.githubusercontent.com/assets/1708733/23070548/6b629ba6-f4f9-11e6-9f7a-64c53d6aab52.png)
